### PR TITLE
Fighter request performance improvement

### DIFF
--- a/api.go
+++ b/api.go
@@ -248,7 +248,7 @@ func (h *FighterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if successfulQuery {
-		log.Printf("returning %d fighters to %s", len(toRet), r.Host)
+		log.Printf("returning %d fighters to %s", len(toRet), r.RemoteAddr)
 		marshalledResponse, err := json.Marshal(toRet)
 		if err != nil {
 			response = []byte(fmt.Sprintf("an error occurred while getting the requested data -- %s", err))

--- a/fighters.go
+++ b/fighters.go
@@ -24,7 +24,7 @@ func (F *Fighters) GetIds() []string {
 	return Ids
 }
 
-func (f *Fighter) MatchesRequest(r *http.Request, c chan Fighter) {
+func (f *Fighter) MatchesRequest(r *http.Request, c chan<- Fighter) {
 	var conditions []bool
 	var toCheck string
 	operatorKeys := []string{"__gt", "__gte", "__lt", "__lte"}


### PR DESCRIPTION
Uses go routines to speed up fighter requests. Matching fighters are sent into a channel which is then read for the results.